### PR TITLE
fix: ArrowFix singleplayer startup crash

### DIFF
--- a/src/main/java/com/github/noamm9/mixin/MixinPlayer.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinPlayer.java
@@ -1,6 +1,5 @@
 package com.github.noamm9.mixin;
 
-import com.github.noamm9.NoammAddons;
 import com.github.noamm9.features.impl.misc.ArrowFix;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -12,6 +11,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static com.github.noamm9.NoammAddons.mc;
+
 @Mixin(Player.class)
 public abstract class MixinPlayer extends LivingEntity {
     protected MixinPlayer(EntityType<? extends LivingEntity> entityType, Level level) {
@@ -21,8 +22,7 @@ public abstract class MixinPlayer extends LivingEntity {
     @Inject(method = "tick", at = @At("HEAD"))
     private void fixPullBack(CallbackInfo ci) {
         if (!ArrowFix.INSTANCE.enabled) return;
-        if ((Player) (Object) this != NoammAddons.mc.player) return;
-        if (useItem.isEmpty()) return;
+        if ((Player) (Object) this != mc.player) return;
         if (ArrowFix.isShortbow(useItem)) {
             useItem = ItemStack.EMPTY;
             useItemRemaining = 0;

--- a/src/main/java/com/github/noamm9/mixin/MixinPlayer.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinPlayer.java
@@ -21,7 +21,8 @@ public abstract class MixinPlayer extends LivingEntity {
     @Inject(method = "tick", at = @At("HEAD"))
     private void fixPullBack(CallbackInfo ci) {
         if (!ArrowFix.INSTANCE.enabled) return;
-        if (NoammAddons.mc.player.getId() != getId()) return;
+        if ((Player) (Object) this != NoammAddons.mc.player) return;
+        if (useItem.isEmpty()) return;
         if (ArrowFix.isShortbow(useItem)) {
             useItem = ItemStack.EMPTY;
             useItemRemaining = 0;


### PR DESCRIPTION
Fixes a crash when joining singleplayer with Arrow Fix enabled.

  `fixPullBack` was reading `mc.player.getId()` during `Player#tick`, but on direct singleplayer join `mc.player` can
  still be null when the integrated server player gets ticked.