### PR TITLE
Refactor PartyFinder, add Party HUD & rules

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
@@ -13,55 +13,77 @@ import com.github.noamm9.utils.ChatUtils
 import com.github.noamm9.utils.ChatUtils.addColor
 import com.github.noamm9.utils.ChatUtils.formattedText
 import com.github.noamm9.utils.ChatUtils.removeFormatting
-import com.github.noamm9.utils.JsonUtils.getDouble
-import com.github.noamm9.utils.JsonUtils.getInt
-import com.github.noamm9.utils.JsonUtils.getObj
 import com.github.noamm9.utils.NumbersUtils.romanToDecimal
 import com.github.noamm9.utils.NumbersUtils.toFixed
 import com.github.noamm9.utils.PartyUtils
 import com.github.noamm9.utils.ThreadUtils
 import com.github.noamm9.utils.Utils.equalsOneOf
+import com.github.noamm9.utils.dungeons.DungeonProfileSummary
+import com.github.noamm9.utils.dungeons.DungeonProfileSummaryProvider
+import com.github.noamm9.utils.dungeons.enums.DungeonClass
 import com.github.noamm9.utils.items.ItemUtils.lore
-import com.github.noamm9.utils.network.ApiUtils
-import com.github.noamm9.utils.network.ProfileUtils
-import com.github.noamm9.utils.network.cache.ProfileCache
 import com.github.noamm9.utils.render.Render2D
 import com.github.noamm9.utils.render.Render2D.width
 import kotlinx.coroutines.launch
 import net.minecraft.network.chat.Component
 import net.minecraft.world.item.Items
 import net.minecraft.world.level.block.Blocks
-import java.util.*
 
 object PartyFinder: Feature() {
-    private val showLevelReq by ToggleSetting("Show Level Req", true).withDescription("Shows the red level requirement number.").section("Menu")
-    private val showMissingOverlay by ToggleSetting("Show Missing Classes", true).withDescription("Shows missing classes on the head.")
+    private val showLevelReq by ToggleSetting("Show Level Req", true)
+        .withDescription("Shows the red level requirement number.")
+        .section("Menu")
+    private val showMissingOverlay by ToggleSetting("Show Missing Classes", true)
+        .withDescription("Shows missing classes on the head.")
 
-    private val showTooltipStats by ToggleSetting("Show Stats", true).withDescription("Shows player stats (Cata/Secrets/PB) in tooltip.").section("Tooltip")
-    private val showSecrets by ToggleSetting("Show Secrets", true).withDescription("Shows Total Secrets and Average.").showIf { showTooltipStats.value }
-    private val showPB by ToggleSetting("Show PB", true).withDescription("Shows Personal Best for the current floor.").showIf { showTooltipStats.value }
-    private val showMissingTooltip by ToggleSetting("Show Missing List", true).withDescription("Shows the list of missing classes at the bottom of the tooltip.")
+    private val showTooltipStats by ToggleSetting("Show Stats", true)
+        .withDescription("Shows player stats (Cata/Secrets/PB) in tooltip.")
+        .section("Tooltip")
+    private val showSecrets by ToggleSetting("Show Secrets", true)
+        .withDescription("Shows total secrets and overall secrets per run.")
+        .showIf { showTooltipStats.value }
+    private val showPB by ToggleSetting("Show PB", true)
+        .withDescription("Shows personal best for the current floor.")
+        .showIf { showTooltipStats.value }
+    private val showMissingTooltip by ToggleSetting("Show Missing List", true)
+        .withDescription("Shows the list of missing classes at the bottom of the tooltip.")
 
-    private val autoKick by ToggleSetting("Auto Kick", false).withDescription("Automatically kick players that don't meet requirements.").section("Auto Kick")
-    private val autoKickFloor by DropdownSetting("Floor", 6, listOf("F1", "F2", "F3", "F4", "F5", "F6", "F7")).showIf { autoKick.value }
+    private val autoKick by ToggleSetting("Auto Kick", false)
+        .withDescription("Automatically kick players that don't meet requirements.")
+        .section("Auto Kick")
+    private val autoKickFloor by DropdownSetting("Floor", 6, listOf("F1", "F2", "F3", "F4", "F5", "F6", "F7"))
+        .showIf { autoKick.value }
     private val masterMode by ToggleSetting("Master Mode", true).showIf { autoKick.value }
-    private val informKicked by ToggleSetting("Inform Kicked", false).withDescription("Send a party chat message before kicking.").showIf { autoKick.value }
-    private val maximumSeconds by SliderSetting("Maximum Seconds", 400, 60, 480, 10, suffix = "s").withDescription("Maximum S+ PB time in seconds.").showIf { autoKick.value }
-    private val minimumSecrets by SliderSetting("Minimum Secrets", 0, 0, 200, 1, suffix = "k").withDescription("Minimum secrets in thousands.").showIf { autoKick.value }
+    private val informKicked by ToggleSetting("Inform Kicked", false)
+        .withDescription("Send a party chat message before kicking.")
+        .showIf { autoKick.value }
+    private val noDupe by ToggleSetting("No Dupe", false)
+        .withDescription("Automatically kicks players who join with a class that is already in your party.")
+        .showIf { autoKick.value }
+    private val minimumPB by ToggleSetting("Minimum PB", true)
+        .withDescription("Require players to have an S+ PB at or under the configured minimum seconds.")
+        .showIf { autoKick.value }
+    private val pbLimitSeconds by SliderSetting("Minimum Seconds", 400, 60, 480, 10, suffix = "s")
+        .withDescription("Players fail if their selected-floor S+ PB is missing or slower than this many seconds.")
+        .showIf { autoKick.value && minimumPB.value }
+    private val minimumSecrets by SliderSetting("Minimum Secrets", 0, 0, 200, 1, suffix = "k")
+        .withDescription("Minimum secrets in thousands.")
+        .showIf { autoKick.value }
+    private val minimumSecretsPerRun by SliderSetting("Minimum Secrets / Run", 0.0, 0.0, 20.0, 0.1)
+        .withDescription("Minimum overall dungeon secrets per run.")
+        .showIf { autoKick.value }
 
-    private val joinedRegex = Regex("^§dParty Finder §f> (.+?) §ejoined the dungeon group! \\(§b(\\w+) Level (\\d+)§e\\)$")
+    private val joinedRegex = Regex("^\\u00a7dParty Finder \\u00a7f> (.+?) \\u00a7ejoined the dungeon group! \\(\\u00a7b(\\w+) Level (\\d+)\\u00a7e\\)$")
     private val kickedPlayers = mutableSetOf<String>()
     private const val prefix = "&9AutoKick &f>"
 
-    private val partyMembersRegex = Regex("§5 (.+)§f: §e(.+)§b \\(..(\\d+)..\\)")
-    private val levelRequiredRegex = Regex("§7Dungeon Level Required: §b(\\d+)")
+    private val partyMembersRegex = Regex("\\u00a75 (.+)\\u00a7f: \\u00a7e(.+)\\u00a7b \\(..(\\d+)..\\)")
+    private val levelRequiredRegex = Regex("\\u00a77Dungeon Level Required: \\u00a7b(\\d+)")
     private val selectedClassRegex = Regex("Currently Selected: (.+)")
-    private val selectDungeonClassRegex = Regex("§7View and select a dungeon class\\.")
+    private val selectDungeonClassRegex = Regex("\\u00a77View and select a dungeon class\\.")
     private val classNames = listOf("&4&lArcher", "&a&lTank", "&6&lBerserk", "&5&lHealer", "&b&lMage")
     private var selectedClass: String? = null
     private var inPartyFinder = false
-
-    private val pendingRequests = Collections.synchronizedSet(HashSet<String>())
 
     private val headSlots = setOf(
         10, 11, 12, 13, 14, 15, 16,
@@ -71,112 +93,140 @@ object PartyFinder: Feature() {
 
     override fun init() {
         register<ContainerEvent.Render.Slot.Post> {
-            if (! inPartyFinder) return@register
+            if (!inPartyFinder) return@register
             if (event.screen.title.string != "Party Finder") return@register
-            if (! showLevelReq.value && ! showMissingOverlay.value) return@register
+            if (!showLevelReq.value && !showMissingOverlay.value) return@register
             if (event.slot.index !in headSlots) return@register
-            val item = event.slot.item.takeUnless { it.isEmpty || ! it.`is`(Blocks.PLAYER_HEAD.asItem()) } ?: return@register
 
+            val item = event.slot.item.takeUnless { it.isEmpty || !it.`is`(Blocks.PLAYER_HEAD.asItem()) } ?: return@register
             val classes = mutableListOf<String>()
             var levelRequired = 0
 
-            for (line in item.lore) when {
-                line.contains("Dungeon Level Required:") && showLevelReq.value -> levelRequired = levelRequiredRegex.find(line)?.groupValues?.get(1)?.toInt() ?: 0
-                partyMembersRegex.matches(line) && showMissingOverlay.value -> classes.add(partyMembersRegex.matchEntire(line) !!.destructured.component2())
+            for (line in item.lore) {
+                when {
+                    line.contains("Dungeon Level Required:") && showLevelReq.value -> {
+                        levelRequired = levelRequiredRegex.find(line)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+                    }
+
+                    partyMembersRegex.matches(line) && showMissingOverlay.value -> {
+                        classes.add(partyMembersRegex.matchEntire(line)?.destructured?.component2().orEmpty())
+                    }
+                }
             }
 
             event.context.pose().translate(event.slot.x.toFloat(), event.slot.y.toFloat())
 
             if (levelRequired != 0) {
-                val str = "&c$levelRequired"
-                Render2D.drawString(event.context, str, 16f - str.width() * 0.6f, 0f, scale = 0.6f)
+                val text = "&c$levelRequired"
+                Render2D.drawString(event.context, text, 16f - text.width() * 0.6f, 0f, scale = 0.6f)
             }
 
             if (showMissingOverlay.value) {
-                val missingClasses = classNames.filter { classes.indexOf(it.removeFormatting()) == - 1 }.map { it.take(5) }
-                val missing = listOf(
+                val missingClasses = classNames
+                    .filter { missingClass -> classes.none { it == missingClass.removeFormatting() } }
+                    .map { it.take(5) }
+
+                val missingLines = listOf(
                     missingClasses.take(2).joinToString(""),
                     missingClasses.drop(2).take(2).joinToString("")
                 ).filter { it.isNotBlank() }
 
-                for ((i, line) in missing.withIndex()) {
+                for ((index, line) in missingLines.withIndex()) {
                     Render2D.drawString(
                         event.context,
                         line,
                         0,
-                        10f - if (i == 1) 6f else 0f,
+                        10f - if (index == 1) 6f else 0f,
                         scale = 0.65
                     )
                 }
             }
 
-            event.context.pose().translate(- event.slot.x.toFloat(), - event.slot.y.toFloat())
+            event.context.pose().translate(-event.slot.x.toFloat(), -event.slot.y.toFloat())
         }
 
         register<ContainerEvent.Render.Tooltip> {
-            if (! inPartyFinder) return@register
+            if (!inPartyFinder) return@register
             if (event.screen.title.string != "Party Finder") return@register
-            if (! event.stack.`is`(Items.PLAYER_HEAD)) return@register
+            if (!event.stack.`is`(Items.PLAYER_HEAD)) return@register
             if (event.screen.menu.slots.find { it.item == event.stack }?.index !in headSlots) return@register
 
             var floor = 0
-            var type = 'F'
-
+            var masterModeTooltip = false
             val remainingClasses = classNames.map { it.removeFormatting() }.toMutableList()
 
-            event.lore.toList().forEachIndexed { index, comp ->
-                val line = comp.formattedText
+            event.lore.toList().forEachIndexed { index, component ->
+                val line = component.formattedText
 
-                if (line.removeFormatting().contains("Dungeon: Master Mode")) type = 'M'
-                if (line.contains("§7Floor: §bFloor ")) floor = line.split(" ").last().let { it.toIntOrNull() ?: it.romanToDecimal() }
+                if (line.removeFormatting().contains("Dungeon: Master Mode")) masterModeTooltip = true
+                if (line.contains("\u00a77Floor: \u00a7bFloor ")) {
+                    val floorText = line.split(" ").last()
+                    floor = floorText.toIntOrNull() ?: floorText.romanToDecimal()
+                }
 
-                partyMembersRegex.matchEntire(line)?.destructured?.let { (pName, cName, cLvl) ->
-                    val playerName = pName.removeFormatting()
-                    val className = cName.removeFormatting()
-                    val level = cLvl.toInt()
-                    val color = getColor(level)
+                partyMembersRegex.matchEntire(line)?.destructured?.let { (playerNameText, classNameText, classLevelText) ->
+                    val playerName = playerNameText.removeFormatting()
+                    val className = classNameText.removeFormatting()
+                    val classLevel = classLevelText.toInt()
+                    val classLevelColor = getColor(classLevel)
+                    val stats = if (showTooltipStats.value) getStats(playerName, floor, masterModeTooltip) else ""
 
-                    val stats = if (showTooltipStats.value) getStats(playerName, floor, type) else ""
-
-                    event.lore[index] = Component.literal(" $pName: §e$className $color$level $stats".addColor())
+                    event.lore[index] = Component.literal(
+                        " $playerNameText: &e$className $classLevelColor$classLevel $stats".addColor()
+                    )
                     remainingClasses.remove(className)
                 }
             }
 
-            if (selectedClass?.removeFormatting() in remainingClasses) {
-                val idx = remainingClasses.indexOf(selectedClass?.removeFormatting())
-                remainingClasses[idx] = "$selectedClass§7"
+            val selectedClassName = selectedClass?.removeFormatting()
+            if (selectedClassName != null && selectedClassName in remainingClasses) {
+                val selectedIndex = remainingClasses.indexOf(selectedClassName)
+                remainingClasses[selectedIndex] = "${selectedClass}&7"
             }
 
             if (showMissingTooltip.value) {
-                event.lore.add(Component.literal("§cMissing: §7" + remainingClasses.joinToString(", ") { it.addColor() }))
+                event.lore.add(
+                    Component.literal(("&cMissing: &7" + remainingClasses.joinToString(", ")).addColor())
+                )
             }
         }
 
         register<ContainerFullyOpenedEvent> {
             if (event.title.string == "Catacombs Gate") {
-                event.items[45]?.lore?.takeIf { it.size > 3 && it[0].matches(selectDungeonClassRegex) }?.run {
-                    selectedClassRegex.matchEntire(get(2).removeFormatting())?.destructured?.run {
-                        selectedClass = classNames[classNames.map { it.removeFormatting() }.indexOf(component1())]
+                event.items[45]?.lore
+                    ?.takeIf { it.size > 3 && selectDungeonClassRegex.matches(it[0]) }
+                    ?.let { lore ->
+                        val selectedName = selectedClassRegex.find(lore[2].removeFormatting())?.groupValues?.getOrNull(1)
+                            ?: return@let
+                        val selectedIndex = classNames.indexOfFirst { it.removeFormatting() == selectedName }
+                        if (selectedIndex != -1) {
+                            selectedClass = classNames[selectedIndex]
+                        }
                     }
-                }
             }
             else if (event.title.string == "Party Finder") {
-                event.items[50]?.takeIf { it.`is`(Items.NETHER_STAR) }?.lore[5]?.let {
-                    if (! it.contains("§aCombat Level: ")) {
-                        inPartyFinder = true
+                event.items[50]
+                    ?.takeIf { it.`is`(Items.NETHER_STAR) }
+                    ?.lore
+                    ?.getOrNull(5)
+                    ?.let {
+                        if (!it.contains("\u00a7aCombat Level: ")) {
+                            inPartyFinder = true
+                        }
                     }
-                }
             }
         }
 
         register<ContainerEvent.Close> { inPartyFinder = false }
-
         register<WorldChangeEvent> { kickedPlayers.clear() }
 
         register<ChatMessageEvent> {
-            if (! autoKick.value || ! PartyUtils.isLeader()) return@register
-            val name = joinedRegex.find(event.formattedText)?.destructured?.component1() ?: return@register
+            if (!autoKick.value || !PartyUtils.isLeader()) return@register
+
+            val joinMatch = joinedRegex.find(event.formattedText) ?: return@register
+            val (joinedName, joinedClassName, _) = joinMatch.destructured
+            val name = joinedName.removeFormatting()
+            val joinedClass = DungeonClass.fromName(joinedClassName)
 
             if (name in kickedPlayers) {
                 ChatUtils.modMessage("$prefix &cAuto-kicking &e$name &c(previously kicked)")
@@ -185,7 +235,7 @@ object PartyFinder: Feature() {
             }
 
             scope.launch {
-                val reasons = checkPlayer(name.removeFormatting()).takeUnless { it.isEmpty() } ?: return@launch
+                val reasons = checkPlayer(name, joinedClass).takeUnless { it.isEmpty() } ?: return@launch
                 kickedPlayers.add(name)
 
                 if (informKicked.value) {
@@ -200,110 +250,90 @@ object PartyFinder: Feature() {
         }
     }
 
-    private suspend fun checkPlayer(name: String): List<String> {
+    private suspend fun checkPlayer(name: String, joinedClass: DungeonClass): List<String> {
+        if (name.equalsOneOf("Noamm", mc.user.name)) return emptyList()
+
         val reasons = mutableListOf<String>()
-        if (name.equalsOneOf("Noamm", mc.user.name)) return reasons
-        val profile = ProfileUtils.getProfile(name).getOrNull() ?: return reasons
+        if (noDupe.value) {
+            PartyFinderRules.duplicateClassReason(joinedClass, currentPartyClasses(name))?.let(reasons::add)
+        }
 
-        val dungeons = profile.getObj("dungeons") ?: return reasons
+        if (!requiresProfileCheck()) {
+            return reasons
+        }
+
         val floor = autoKickFloor.value + 1
-        val dungeonType = if (masterMode.value) dungeons.getObj("master_catacombs") else dungeons.getObj("catacombs")
+        val pbFloor = floor.takeIf { minimumPB.value }
+        val summary = DungeonProfileSummaryProvider.loadSummary(name, pbFloor, masterMode.value) ?: return reasons
 
-        val floorPrefix = if (masterMode.value) "M" else "F"
-        val pbReq = formatTime(maximumSeconds.value * 1000)
-        val pb = dungeonType?.getObj("fastest_time_s_plus")?.getInt("$floor")?.div(1000)
-        if (pb == null) reasons.add("PB(No S+/$pbReq)")
-        else if (pb / 1000 > maximumSeconds.value) {
-            reasons.add("$floorPrefix$floor: PB(${formatTime(pb)}/$pbReq)")
-        }
-
-        if (minimumSecrets.value > 0) {
-            val secrets = dungeons.getInt("secrets") ?: 0
-            if (secrets < minimumSecrets.value * 1000) {
-                reasons.add("Secrets(${secrets / 1000}k/${minimumSecrets.value}k)")
-            }
-        }
-
+        reasons += PartyFinderRules.evaluate(
+            summary,
+            PartyFinderRuleConfig(
+                floor = floor,
+                masterMode = masterMode.value,
+                enforcePbLimit = minimumPB.value,
+                pbLimitSeconds = pbLimitSeconds.value,
+                minimumSecretsThousands = minimumSecrets.value,
+                minimumSecretsPerRun = minimumSecretsPerRun.value,
+            )
+        )
         return reasons
     }
 
-    private fun getStats(name: String, floor: Int, type: Char): String {
-        val key = name.removeFormatting().uppercase()
-        val cachedData = ProfileCache.getFromCache(key)
+    private fun getStats(name: String, floor: Int, masterMode: Boolean): String {
+        val summary = DungeonProfileSummaryProvider.getSummaryOrRequest(
+            playerName = name,
+            floor = floor.takeIf { it > 0 },
+            masterMode = masterMode
+        ) ?: return "&7(Loading...)"
 
-        if (cachedData == null) {
-            if (! pendingRequests.contains(key) && pendingRequests.size < 5) {
-                pendingRequests.add(key)
+        return formatStats(summary)
+    }
 
-                scope.launch {
-                    try {
-                        ProfileUtils.getProfile(key).getOrThrow()
-                    }
-                    catch (e: Exception) {
-                        e.printStackTrace()
-                    }
-                    finally {
-                        pendingRequests.remove(key)
-                    }
-                }
-            }
-            return "§7(Loading...)"
-        }
-
-        val dungeons = cachedData.getObj("dungeons")
-        val catacombs = dungeons?.getObj("catacombs")
-        val masterCatacombs = dungeons?.getObj("master_catacombs")
-
-        val cataLvl = dungeons?.getDouble("catacombs_experience")?.let { ApiUtils.getCatacombsLevel(it) } ?: "?"
-
+    private fun formatStats(summary: DungeonProfileSummary): String {
         return buildString {
-            append("§b(§6$cataLvl§b)§r")
+            append("&b(&6${summary.catacombsLevel ?: "?"}&b)&r")
 
             if (showSecrets.value) {
-                val totalSecrets = dungeons?.getInt("secrets")?.toDouble() ?: .0
-                val totalRuns = dungeons?.getInt("total_runs")?.toDouble() ?: .0
-                val secretAvg = if (totalRuns > 0) (totalSecrets / totalRuns).toFixed(2) else "0.00"
-                val showSecretsVal = totalSecrets != .0
-                val secrets = if (showSecretsVal) totalSecrets.toInt() else "?"
-                val avg = if (showSecretsVal) secretAvg else "?"
-
-                append(" §8[§a$secrets§8/§b$avg§8]§r")
+                val secrets = summary.totalSecrets?.toString() ?: "?"
+                val secretsPerRun = summary.secretsPerRun?.toFixed(2) ?: "?"
+                append(" &8[&a$secrets&8/&b$secretsPerRun&8]&r")
             }
 
             if (showPB.value) {
-                val pbObj = if (type == 'F') catacombs else masterCatacombs
-                val pbTime = pbObj?.getObj("fastest_time_s_plus")?.getInt("$floor")
-                val pb = pbTime?.let(::formatTime) ?: "N/A"
-                append(" §8[§9$pb§8]§r")
+                val pb = summary.floorPbMilliseconds?.let(PartyFinderRules::formatDuration) ?: "N/A"
+                append(" &8[&9$pb&8]&r")
             }
         }
     }
 
-
     private fun getColor(level: Int) = when {
-        level >= 50 -> "§c§l"
-        level >= 45 -> "§c"
-        level >= 40 -> "§6"
-        level >= 35 -> "§d"
-        level >= 30 -> "§9"
-        level >= 25 -> "§b"
-        level >= 20 -> "§2"
-        level >= 15 -> "§a"
-        level >= 10 -> "§e"
-        level >= 5 -> "§f"
-        else -> "§7"
+        level >= 50 -> "&c&l"
+        level >= 45 -> "&c"
+        level >= 40 -> "&6"
+        level >= 35 -> "&d"
+        level >= 30 -> "&9"
+        level >= 25 -> "&b"
+        level >= 20 -> "&2"
+        level >= 15 -> "&a"
+        level >= 10 -> "&e"
+        level >= 5 -> "&f"
+        else -> "&7"
     }
 
-    private fun formatTime(milliseconds: Number): String {
-        val totalSecs = milliseconds.toLong() / 1000
-        val h = totalSecs / 3600
-        val m = (totalSecs % 3600) / 60
-        val s = totalSecs % 60
+    private fun requiresProfileCheck() = minimumPB.value || minimumSecrets.value > 0 || minimumSecretsPerRun.value > 0
 
-        return buildList {
-            if (h > 0) add(h)
-            if (m > 0) add(m)
-            if (s > 0) add(s)
-        }.joinToString(":")
+    private fun currentPartyClasses(excludeName: String): Set<DungeonClass> {
+        val classes = PartyUtils.members.asSequence()
+            .filter { !it.equals(excludeName, ignoreCase = true) }
+            .mapNotNull { PartyUtils.getDungeonMemberInfo(it)?.dungeonClass?.takeUnless { clazz -> clazz == DungeonClass.Empty } }
+            .toMutableSet()
+
+        selectedClass?.removeFormatting()
+            ?.let(DungeonClass::fromName)
+            ?.takeUnless { it == DungeonClass.Empty || mc.user.name.equals(excludeName, ignoreCase = true) }
+            ?.let(classes::add)
+
+        return classes
     }
 }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
@@ -131,7 +131,7 @@ object PartyFinder: Feature() {
                     missingClasses.drop(2).take(2).joinToString("")
                 ).filter { it.isNotBlank() }
 
-                for ((index, line) in missingLines.withIndex()) {
+                for ((i, line) in missingLines.withIndex()) {
                     Render2D.drawString(
                         event.context,
                         line,

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinderRules.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinderRules.kt
@@ -1,0 +1,70 @@
+package com.github.noamm9.features.impl.dungeon
+
+import com.github.noamm9.utils.NumbersUtils.toFixed
+import com.github.noamm9.utils.dungeons.DungeonProfileSummary
+import com.github.noamm9.utils.dungeons.enums.DungeonClass
+import java.util.Locale
+
+data class PartyFinderRuleConfig(
+    val floor: Int,
+    val masterMode: Boolean,
+    val enforcePbLimit: Boolean = true,
+    val pbLimitSeconds: Int,
+    val minimumSecretsThousands: Int = 0,
+    val minimumSecretsPerRun: Double = 0.0,
+)
+
+object PartyFinderRules {
+    fun duplicateClassReason(joiningClass: DungeonClass, currentClasses: Collection<DungeonClass>): String? {
+        if (joiningClass == DungeonClass.Empty) return null
+        return if (currentClasses.any { it == joiningClass }) "Dupe(${joiningClass.name})"
+        else null
+    }
+
+    fun evaluate(summary: DungeonProfileSummary, config: PartyFinderRuleConfig): List<String> {
+        val reasons = mutableListOf<String>()
+
+        if (config.enforcePbLimit) {
+            val pbLimit = formatDuration(config.pbLimitSeconds * 1000L)
+            val pbMilliseconds = summary.floorPbMilliseconds
+
+            if (pbMilliseconds == null) {
+                reasons.add("PB(No S+/$pbLimit)")
+            }
+            else if (pbMilliseconds / 1000 > config.pbLimitSeconds) {
+                val floorPrefix = if (config.masterMode) "M" else "F"
+                reasons.add("$floorPrefix${config.floor}: PB(${formatDuration(pbMilliseconds)}/$pbLimit)")
+            }
+        }
+
+        if (config.minimumSecretsThousands > 0) {
+            val secrets = summary.totalSecrets ?: 0
+            if (secrets < config.minimumSecretsThousands * 1000) {
+                reasons.add("Secrets(${secrets / 1000}k/${config.minimumSecretsThousands}k)")
+            }
+        }
+
+        if (config.minimumSecretsPerRun > 0) {
+            val secretsPerRun = summary.secretsPerRun ?: 0.0
+            if (secretsPerRun < config.minimumSecretsPerRun) {
+                reasons.add("SPR(${secretsPerRun.toFixed(2)}/${config.minimumSecretsPerRun.toFixed(2)})")
+            }
+        }
+
+        return reasons
+    }
+
+    fun formatDuration(milliseconds: Number): String {
+        val totalSeconds = milliseconds.toLong() / 1000L
+        val hours = totalSeconds / 3600L
+        val minutes = (totalSeconds % 3600L) / 60L
+        val seconds = totalSeconds % 60L
+
+        return if (hours > 0) {
+            String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        else {
+            String.format(Locale.US, "%d:%02d", minutes, seconds)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyHud.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyHud.kt
@@ -1,0 +1,193 @@
+package com.github.noamm9.features.impl.dungeon
+
+import com.github.noamm9.event.impl.MouseClickEvent
+import com.github.noamm9.features.Feature
+import com.github.noamm9.ui.clickgui.components.getValue
+import com.github.noamm9.ui.clickgui.components.impl.ToggleSetting
+import com.github.noamm9.ui.clickgui.components.provideDelegate
+import com.github.noamm9.ui.clickgui.components.section
+import com.github.noamm9.ui.clickgui.components.withDescription
+import com.github.noamm9.ui.hud.HudElement
+import com.github.noamm9.ui.utils.Resolution
+import com.github.noamm9.utils.ChatUtils
+import com.github.noamm9.utils.PartyUtils
+import com.github.noamm9.utils.dungeons.DungeonListener
+import com.github.noamm9.utils.dungeons.DungeonProfileSummaryProvider
+import com.github.noamm9.utils.dungeons.enums.DungeonClass
+import com.github.noamm9.utils.location.LocationUtils
+import com.github.noamm9.utils.render.Render2D
+import com.github.noamm9.utils.render.Render2D.width
+import net.minecraft.client.gui.screens.ChatScreen
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import org.lwjgl.glfw.GLFW
+
+object PartyHud: Feature(
+    name = "Party HUD",
+    description = "Displays party dungeon stats including class, cata, secrets, and PB."
+) {
+    private data class KickButtonHitbox(
+        val playerName: String,
+        val x: Float,
+        val y: Float,
+        val width: Float,
+        val height: Float,
+    )
+
+    private val kickButtonHitboxes = mutableListOf<KickButtonHitbox>()
+    private val kickColumnWidth = 8f
+
+    private val showInDungeons by ToggleSetting("Show In Dungeons", true)
+        .withDescription("Allows Party HUD to render while you are inside dungeons.")
+        .section("Behavior")
+    private val showOutsideDungeons by ToggleSetting("Show Outside Dungeons", true)
+        .withDescription("Allows Party HUD to render outside active dungeons using party fallback data.")
+    private val includeSelf by ToggleSetting("Include Self", true)
+        .withDescription("Includes your own player row in the Party HUD.")
+
+    private val showClassName by ToggleSetting("Class", true)
+        .withDescription("Displays the dungeon class name.")
+        .section("Columns")
+    private val showClassLevel by ToggleSetting("Class Level", true)
+        .withDescription("Displays the dungeon class level.")
+    private val showSecretsStats by ToggleSetting("Secrets Stats", true)
+        .withDescription("Displays [total secrets/secrets per run].")
+    private val showCatacombsLevel by ToggleSetting("Catacombs Level", true)
+        .withDescription("Displays catacombs level.")
+    private val showPersonalBest by ToggleSetting("Personal Best", true)
+        .withDescription("Displays the selected-floor S+ PB when the current floor is known.")
+
+    private val partyHudElement = object: HudElement() {
+        override val name = "Party HUD"
+        override val toggle get() = this@PartyHud.enabled
+        override val shouldDraw get() = mc.player != null && hudMembers().isNotEmpty()
+
+        override fun draw(ctx: net.minecraft.client.gui.GuiGraphics, example: Boolean): Pair<Float, Float> {
+            kickButtonHitboxes.clear()
+            val displayConfig = displayConfig()
+            val showKickButtons = !example && canClickKickButtons()
+
+            if (example) {
+                val rows = PartyHudFormatter.previewRows(displayConfig)
+                if (rows.isEmpty()) return 0f to 0f
+
+                var maxWidth = 0f
+                rows.forEachIndexed { index, row ->
+                    Render2D.drawString(ctx, row, 0f, index * 9f)
+                    maxWidth = maxOf(maxWidth, row.width().toFloat())
+                }
+
+                return maxWidth to rows.size * 9f
+            }
+
+            val members = hudMembers()
+            if (members.isEmpty()) return 0f to 0f
+
+            val floor = LocationUtils.dungeonFloorNumber?.takeIf { it > 0 }
+            val masterMode = LocationUtils.isMasterMode
+            var maxWidth = 0f
+            members.forEachIndexed { index, member ->
+                val summary = if (displayConfig.usesProfileSummary) {
+                    DungeonProfileSummaryProvider.getSummaryOrRequest(member.name, floor, masterMode)
+                }
+                else null
+
+                val row = PartyHudFormatter.formatRow(member, summary, displayConfig)
+                val rowY = index * 9f
+                val rowX = if (showKickButtons) kickColumnWidth else 0f
+
+                if (showKickButtons && !member.name.equals(mc.user.name, ignoreCase = true)) {
+                    Render2D.drawString(ctx, "&cX", 0f, rowY)
+                    kickButtonHitboxes.add(
+                        KickButtonHitbox(
+                            playerName = member.name,
+                            x = x,
+                            y = y + rowY * scale,
+                            width = kickColumnWidth * scale,
+                            height = 9f * scale,
+                        )
+                    )
+                }
+
+                Render2D.drawString(ctx, row, rowX, rowY)
+                maxWidth = maxOf(maxWidth, rowX + row.width().toFloat())
+            }
+
+            return maxWidth to members.size * 9f
+        }
+    }.also(hudElements::add)
+
+    private fun hudMembers(): List<PartyHudMember> {
+        val selfName = mc.player?.name?.string
+        if (LocationUtils.inDungeon) {
+            if (!showInDungeons.value) return emptyList()
+
+            if (DungeonListener.dungeonTeammates.isNotEmpty()) {
+                return DungeonListener.dungeonTeammates
+                    .asSequence()
+                    .filter { includeSelf.value || it.name != selfName }
+                    .map { PartyHudMember(it.name, it.clazz, it.clazzLvl) }
+                    .toList()
+            }
+        }
+
+        if (!showOutsideDungeons.value) {
+            return emptyList()
+        }
+
+        val orderedMembers = LinkedHashSet<String>()
+        PartyUtils.members.forEach(orderedMembers::add)
+        if (includeSelf.value) {
+            selfName?.let(orderedMembers::add)
+        }
+
+        return orderedMembers.map { playerName ->
+            PartyUtils.getDungeonMemberInfo(playerName)?.let { info ->
+                PartyHudMember(playerName, info.dungeonClass, info.classLevel)
+            } ?: PartyHudMember(playerName, DungeonClass.Empty, null)
+        }
+    }
+
+    private fun displayConfig() = PartyHudDisplayConfig(
+        showClassName = showClassName.value,
+        showClassLevel = showClassLevel.value,
+        showSecretsStats = showSecretsStats.value,
+        showCatacombsLevel = showCatacombsLevel.value,
+        showPersonalBest = showPersonalBest.value,
+    )
+
+    override fun init() {
+        register<MouseClickEvent> {
+            if (event.button != GLFW.GLFW_MOUSE_BUTTON_LEFT) return@register
+            if (event.action != GLFW.GLFW_PRESS) return@register
+            if (!canClickKickButtons()) return@register
+            if (kickButtonHitboxes.isEmpty()) return@register
+
+            Resolution.refresh()
+            val mouseX = Resolution.getMouseX()
+            val mouseY = Resolution.getMouseY()
+            val hitbox = kickButtonHitboxes.firstOrNull {
+                mouseX >= it.x && mouseX <= it.x + it.width &&
+                    mouseY >= it.y && mouseY <= it.y + it.height
+            } ?: return@register
+
+            ChatUtils.sendCommand("party kick ${hitbox.playerName}")
+            event.isCanceled = true
+        }
+    }
+
+    override fun onDisable() {
+        kickButtonHitboxes.clear()
+        super.onDisable()
+    }
+
+    private fun canClickKickButtons(): Boolean {
+        if (!enabled) return false
+        if (mc.player == null || hudMembers().isEmpty()) return false
+        if (!PartyUtils.isLeader()) return false
+        return when (mc.screen) {
+            is ChatScreen -> true
+            is AbstractContainerScreen<*> -> true
+            else -> false
+        }
+    }
+}

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyHudFormatter.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyHudFormatter.kt
@@ -1,0 +1,110 @@
+package com.github.noamm9.features.impl.dungeon
+
+import com.github.noamm9.utils.NumbersUtils.toFixed
+import com.github.noamm9.utils.dungeons.DungeonProfileSummary
+import com.github.noamm9.utils.dungeons.enums.DungeonClass
+
+data class PartyHudMember(
+    val name: String,
+    val dungeonClass: DungeonClass,
+    val classLevel: Int?,
+)
+
+data class PartyHudDisplayConfig(
+    val showClassName: Boolean = true,
+    val showClassLevel: Boolean = true,
+    val showSecretsStats: Boolean = true,
+    val showCatacombsLevel: Boolean = true,
+    val showPersonalBest: Boolean = true,
+) {
+    val usesProfileSummary: Boolean
+        get() = showClassName || showClassLevel || showSecretsStats || showCatacombsLevel || showPersonalBest
+}
+
+object PartyHudFormatter {
+    fun buildRows(
+        members: Iterable<PartyHudMember>,
+        config: PartyHudDisplayConfig = PartyHudDisplayConfig(),
+        summaryLookup: (String) -> DungeonProfileSummary?
+    ): List<String> {
+        return members.map { formatRow(it, summaryLookup(it.name), config) }
+    }
+
+    fun formatRow(
+        member: PartyHudMember,
+        summary: DungeonProfileSummary?,
+        config: PartyHudDisplayConfig = PartyHudDisplayConfig(),
+    ): String {
+        val resolvedClass = member.dungeonClass.takeUnless { it == DungeonClass.Empty }
+            ?: summary?.selectedClass
+            ?: summary?.bestClass
+            ?: DungeonClass.Empty
+        val classLevel = member.classLevel
+            ?: summary?.let {
+                when (resolvedClass) {
+                    it.selectedClass -> it.selectedClassLevel
+                    it.bestClass -> it.bestClassLevel
+                    else -> null
+                }
+            }
+        val classColor = classColor(resolvedClass)
+        val classNameText = className(resolvedClass)
+        val classLevelText = classLevel?.toString() ?: "?"
+        val catacombsLevelText = summary?.catacombsLevel?.toString() ?: "?"
+        val totalSecretsText = summary?.totalSecrets?.toString() ?: "?"
+        val secretsPerRunText = summary?.secretsPerRun?.toFixed(2) ?: "?"
+        val personalBestText = summary?.floorPbMilliseconds?.let(PartyFinderRules::formatDuration) ?: "?"
+
+        val detailSegments = buildList {
+            val classSegments = buildList {
+                if (config.showClassName) add(classNameText)
+                if (config.showClassLevel) add(classLevelText)
+            }
+            if (classSegments.isNotEmpty()) {
+                add("$classColor${classSegments.joinToString(" ")}&r")
+            }
+
+            if (config.showCatacombsLevel) {
+                add("&e($catacombsLevelText)&r")
+            }
+
+            if (config.showSecretsStats) {
+                add("&a[$totalSecretsText/$secretsPerRunText]&r")
+            }
+
+            if (config.showPersonalBest) {
+                add("&9[$personalBestText]&r")
+            }
+        }
+
+        val prefix = "${classColor}${member.name}&r:"
+        return if (detailSegments.isEmpty()) prefix
+        else "$prefix  ${detailSegments.joinToString(" ")}"
+    }
+
+    fun previewRows(config: PartyHudDisplayConfig = PartyHudDisplayConfig()): List<String> {
+        val previewData = listOf(
+            PartyHudMember("ArcherGuy", DungeonClass.Archer, 50) to DungeonProfileSummary(53, 17_400, 2_900, 6.0, 271_000, DungeonClass.Archer, 50, DungeonClass.Archer, 50),
+            PartyHudMember("MageMain", DungeonClass.Mage, 49) to DungeonProfileSummary(52, 24_300, 3_000, 8.1, 274_000, DungeonClass.Mage, 49, DungeonClass.Mage, 49),
+            PartyHudMember("HealBot", DungeonClass.Healer, 44) to DungeonProfileSummary(48, 12_600, 2_400, 5.25, 332_000, DungeonClass.Healer, 44, DungeonClass.Healer, 44),
+            PartyHudMember("Tanky", DungeonClass.Tank, 41) to DungeonProfileSummary(47, 11_200, 2_800, 4.0, 359_000, DungeonClass.Tank, 41, DungeonClass.Tank, 41),
+            PartyHudMember("Bers", DungeonClass.Berserk, 46) to DungeonProfileSummary(50, 16_500, 2_750, 6.0, 287_000, DungeonClass.Berserk, 46, DungeonClass.Berserk, 46),
+        )
+
+        return previewData.map { (member, summary) -> formatRow(member, summary, config) }
+    }
+
+    private fun className(dungeonClass: DungeonClass) = dungeonClass
+        .takeUnless { it == DungeonClass.Empty }
+        ?.name
+        ?: "?"
+
+    private fun classColor(dungeonClass: DungeonClass) = when (dungeonClass) {
+        DungeonClass.Archer -> "&4"
+        DungeonClass.Mage -> "&3"
+        DungeonClass.Healer -> "&5"
+        DungeonClass.Tank -> "&2"
+        DungeonClass.Berserk -> "&6"
+        DungeonClass.Empty -> "&7"
+    }
+}

--- a/src/main/kotlin/com/github/noamm9/utils/PartyUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/PartyUtils.kt
@@ -4,6 +4,7 @@ import com.github.noamm9.NoammAddons.mc
 import com.github.noamm9.event.EventBus.register
 import com.github.noamm9.event.EventPriority
 import com.github.noamm9.event.impl.ChatMessageEvent
+import com.github.noamm9.utils.dungeons.enums.DungeonClass
 import com.github.noamm9.utils.location.LocationUtils
 
 
@@ -12,6 +13,11 @@ import com.github.noamm9.utils.location.LocationUtils
  * @link https://github.com/odtheking/OdinFabric/blob/main/src/main/kotlin/com/odtheking/odin/utils/skyblock/PartyUtils.kt
  */
 object PartyUtils {
+    data class DungeonMemberInfo(
+        val dungeonClass: DungeonClass,
+        val classLevel: Int,
+    )
+
     private val joinedSelf = Regex("^You have joined ((?:\\[[^]]*?])? ?)?(\\w{1,16})'s? party!$")
     private val joinedOther = Regex("^((?:\\[[^]]*?])? ?)?(\\w{1,16}) joined the party\\.$")
     private val leftParty = Regex("^((?:\\[[^]]*?])? ?)?(\\w{1,16}) has left the party\\.$")
@@ -42,12 +48,15 @@ object PartyUtils {
     )
 
     val members = mutableListOf<String>()
+    private val dungeonMemberInfo = mutableMapOf<String, DungeonMemberInfo>()
 
     var partyLeader: String? = null
         private set
 
     var isInParty: Boolean = false
         private set
+
+    fun getDungeonMemberInfo(playerName: String): DungeonMemberInfo? = dungeonMemberInfo[playerName.lowercase()]
 
     fun init() {
         register<ChatMessageEvent>(EventPriority.HIGHEST) {
@@ -137,7 +146,14 @@ object PartyUtils {
 
             kuudraJoin.find(message)?.let { return@register addMember(it.groupValues[2]) }
 
-            dungeonJoin.find(message)?.let { return@register addMember(it.groupValues[1]) }
+            dungeonJoin.find(message)?.let {
+                addMember(it.groupValues[1])
+                dungeonMemberInfo[it.groupValues[1].lowercase()] = DungeonMemberInfo(
+                    DungeonClass.fromName(it.groupValues[2]),
+                    it.groupValues[3].toInt()
+                )
+                return@register
+            }
         }
     }
 
@@ -151,11 +167,13 @@ object PartyUtils {
     private fun removeMember(playerName: String) {
         if (playerName !in members) return
         members.remove(playerName)
+        dungeonMemberInfo.remove(playerName.lowercase())
         if (members.isEmpty()) disband()
     }
 
     private fun disband() {
         members.clear()
+        dungeonMemberInfo.clear()
         partyLeader = null
         isInParty = false
     }

--- a/src/main/kotlin/com/github/noamm9/utils/dungeons/DungeonProfileSummaryProvider.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/dungeons/DungeonProfileSummaryProvider.kt
@@ -1,0 +1,128 @@
+package com.github.noamm9.utils.dungeons
+
+import com.github.noamm9.NoammAddons
+import com.github.noamm9.utils.ChatUtils.removeFormatting
+import com.github.noamm9.utils.JsonUtils.getDouble
+import com.github.noamm9.utils.JsonUtils.getInt
+import com.github.noamm9.utils.JsonUtils.getObj
+import com.github.noamm9.utils.JsonUtils.getString
+import com.github.noamm9.utils.dungeons.enums.DungeonClass
+import com.github.noamm9.utils.network.ApiUtils
+import com.github.noamm9.utils.network.ProfileUtils
+import com.github.noamm9.utils.network.cache.ProfileCache
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.serialization.json.JsonObject
+import java.util.concurrent.ConcurrentHashMap
+
+data class DungeonProfileSummary(
+    val catacombsLevel: Int?,
+    val totalSecrets: Int?,
+    val totalRuns: Int?,
+    val secretsPerRun: Double?,
+    val floorPbMilliseconds: Int?,
+    val selectedClass: DungeonClass?,
+    val selectedClassLevel: Int?,
+    val bestClass: DungeonClass?,
+    val bestClassLevel: Int?,
+)
+
+object DungeonProfileSummaryProvider {
+    private val pendingProfiles = ConcurrentHashMap<String, Deferred<Result<JsonObject>>>()
+
+    fun summarize(profile: JsonObject, floor: Int? = null, masterMode: Boolean = false): DungeonProfileSummary {
+        val dungeons = profile.getObj("dungeons")
+        val totalSecrets = dungeons?.getInt("secrets")
+        val totalRuns = dungeons?.getInt("total_runs")
+        val selectedMode = if (masterMode) dungeons?.getObj("master_catacombs") else dungeons?.getObj("catacombs")
+        val classLevels = extractClassLevels(dungeons)
+        val selectedClass = dungeons?.getString("selected_dungeon_class")
+            ?.let(DungeonClass::fromName)
+            ?.takeUnless { it == DungeonClass.Empty }
+        val bestClassEntry = classLevels.maxByOrNull { it.value }
+
+        return DungeonProfileSummary(
+            catacombsLevel = dungeons?.getDouble("catacombs_experience")?.let(ApiUtils::getCatacombsLevel),
+            totalSecrets = totalSecrets,
+            totalRuns = totalRuns,
+            secretsPerRun = when {
+                totalRuns == null -> null
+                totalRuns == 0 -> 0.0
+                totalSecrets == null -> null
+                else -> totalSecrets.toDouble() / totalRuns.toDouble()
+            },
+            floorPbMilliseconds = floor?.takeIf { it > 0 }
+                ?.let { selectedMode?.getObj("fastest_time_s_plus")?.getInt("$it") },
+            selectedClass = selectedClass,
+            selectedClassLevel = selectedClass?.let(classLevels::get),
+            bestClass = bestClassEntry?.key,
+            bestClassLevel = bestClassEntry?.value,
+        )
+    }
+
+    fun getCachedSummary(playerName: String, floor: Int? = null, masterMode: Boolean = false): DungeonProfileSummary? {
+        val key = cacheKey(playerName)
+        val profile = ProfileCache.getFromCache(key) ?: return null
+        return summarize(profile, floor, masterMode)
+    }
+
+    fun getSummaryOrRequest(playerName: String, floor: Int? = null, masterMode: Boolean = false): DungeonProfileSummary? {
+        return getCachedSummary(playerName, floor, masterMode) ?: run {
+            requestProfile(playerName)
+            null
+        }
+    }
+
+    suspend fun loadSummary(playerName: String, floor: Int? = null, masterMode: Boolean = false): DungeonProfileSummary? {
+        return loadProfile(playerName).getOrNull()?.let { summarize(it, floor, masterMode) }
+    }
+
+    private suspend fun loadProfile(playerName: String): Result<JsonObject> {
+        val key = cacheKey(playerName)
+        ProfileCache.getFromCache(key)?.let { return Result.success(it) }
+        return pendingProfiles[key]?.await() ?: requestProfile(playerName).await()
+    }
+
+    private fun requestProfile(playerName: String): Deferred<Result<JsonObject>> {
+        val cleanName = cleanName(playerName)
+        val key = cleanName.lowercase()
+
+        ProfileCache.getFromCache(key)?.let { return CompletableDeferred(Result.success(it)) }
+
+        return pendingProfiles.computeIfAbsent(key) {
+            NoammAddons.scope.async {
+                try {
+                    ProfileUtils.getProfile(cleanName)
+                }
+                finally {
+                    pendingProfiles.remove(key)
+                }
+            }
+        }
+    }
+
+    private fun cacheKey(playerName: String) = cleanName(playerName).lowercase()
+
+    private fun cleanName(playerName: String) = playerName.removeFormatting()
+
+    private fun extractClassLevels(dungeons: JsonObject?): Map<DungeonClass, Int> {
+        if (dungeons == null) return emptyMap()
+
+        val playerClasses = dungeons.getObj("player_classes")
+
+        return listOf(
+            DungeonClass.Archer to "archer",
+            DungeonClass.Berserk to "berserk",
+            DungeonClass.Healer to "healer",
+            DungeonClass.Mage to "mage",
+            DungeonClass.Tank to "tank",
+        ).mapNotNull { (dungeonClass, key) ->
+            val experience = playerClasses?.getDouble(key)
+                ?: playerClasses?.getObj(key)?.getDouble("experience")
+                ?: dungeons.getDouble("${key}_experience")
+                ?: return@mapNotNull null
+            dungeonClass to ApiUtils.getCatacombsLevel(experience)
+        }.toMap()
+    }
+}


### PR DESCRIPTION
Large refactor of dungeon party features: PartyFinder was cleaned up and reworked to use a new DungeonProfileSummaryProvider and PartyFinderRules for profile summarization and auto-kick evaluation. Added PartyHud and PartyHudFormatter to render a configurable party HUD with clickable kick buttons. PartyUtils now tracks dungeon member class info. New provider centralizes profile parsing/caching (DungeonProfileSummaryProvider) and avoids ad-hoc profile parsing and pendingRequests. Several new settings were added (PB limits, no-dupe, secrets-per-run, etc.), regex/formatting was normalized (color codes), and helper methods (formatting, class color/name, current party class detection) were introduced.