### PR TITLE
feat: add lever overlay dungeon only

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/LeverOverlay.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/LeverOverlay.kt
@@ -3,7 +3,9 @@ package com.github.noamm9.features.impl.dungeon
 import com.github.noamm9.config.types.ColorSetting
 import com.github.noamm9.config.types.DropdownSetting
 import com.github.noamm9.config.types.SliderSetting
+//#if CHEAT
 import com.github.noamm9.config.types.ToggleSetting
+//#endif
 import com.github.noamm9.event.impl.RenderWorldEvent
 import com.github.noamm9.event.impl.TickEvent
 import com.github.noamm9.features.Feature
@@ -21,11 +23,13 @@ object LeverOverlay: Feature(description = "Highlights lever hitboxes") {
     private val fillColor by ColorSetting("Fill Color", Utils.favoriteColor.withAlpha(50)).hideIf { mode.value == 0 }
     private val outlineColor by ColorSetting("Outline Color", Utils.favoriteColor, false).hideIf { mode.value == 1 }
     private val lineWidth by SliderSetting("Line Width", 2.5, 1, 10, 0.1).hideIf { mode.value == 1 }
+    //#if CHEAT
     private val phase by ToggleSetting("See Through Walls")
+    //#endif
 
     private val nearbyLevers = mutableSetOf<BlockPos>()
     private var tickCounter = 0
-    private const val RADIUS = 16
+    private const val RADIUS = 32
 
     override fun init() {
         register<TickEvent.End> {
@@ -50,7 +54,19 @@ object LeverOverlay: Feature(description = "Highlights lever hitboxes") {
             val outline = mode.value.equalsOneOf(0, 2)
             val fill = mode.value.equalsOneOf(1, 2)
 
-            for (pos in nearbyLevers) event.ctx.renderBlock(pos, outlineColor.value, fillColor.value, outline, fill, phase.value, lineWidth.value)
+            for (pos in nearbyLevers) event.ctx.renderBlock(
+                pos,
+                outlineColor.value,
+                fillColor.value,
+                outline,
+                fill,
+                //#if CHEAT
+                phase.value,
+                //#else
+                //$false,
+                //#endif
+                lineWidth.value
+            )
         }
     }
 }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/LeverOverlay.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/LeverOverlay.kt
@@ -1,0 +1,56 @@
+package com.github.noamm9.features.impl.dungeon
+
+import com.github.noamm9.config.types.ColorSetting
+import com.github.noamm9.config.types.DropdownSetting
+import com.github.noamm9.config.types.SliderSetting
+import com.github.noamm9.config.types.ToggleSetting
+import com.github.noamm9.event.impl.RenderWorldEvent
+import com.github.noamm9.event.impl.TickEvent
+import com.github.noamm9.features.Feature
+import com.github.noamm9.utils.ColorUtils.withAlpha
+import com.github.noamm9.utils.Utils
+import com.github.noamm9.utils.WorldUtils
+import com.github.noamm9.utils.equalsOneOf
+import com.github.noamm9.utils.location.LocationUtils
+import com.github.noamm9.utils.render.world.Render3D.renderBlock
+import net.minecraft.core.BlockPos
+import net.minecraft.world.level.block.LeverBlock
+
+object LeverOverlay: Feature(description = "Highlights lever hitboxes") {
+    private val mode by DropdownSetting("Mode", 2, listOf("Outline", "Fill", "Filled Outline"))
+    private val fillColor by ColorSetting("Fill Color", Utils.favoriteColor.withAlpha(50)).hideIf { mode.value == 0 }
+    private val outlineColor by ColorSetting("Outline Color", Utils.favoriteColor, false).hideIf { mode.value == 1 }
+    private val lineWidth by SliderSetting("Line Width", 2.5, 1, 10, 0.1).hideIf { mode.value == 1 }
+    private val phase by ToggleSetting("See Through Walls")
+
+    private val nearbyLevers = mutableSetOf<BlockPos>()
+    private var tickCounter = 0
+    private const val RADIUS = 16
+
+    override fun init() {
+        register<TickEvent.End> {
+            if (! LocationUtils.inDungeon) return@register
+            if (tickCounter++ % 10 != 0) return@register
+
+            val center = player.blockPosition()
+            val found = mutableSetOf<BlockPos>()
+
+            for (pos in BlockPos.betweenClosed(center.offset(- RADIUS, - RADIUS, - RADIUS), center.offset(RADIUS, RADIUS, RADIUS))) {
+                if (WorldUtils.getBlockAt(pos) is LeverBlock) found.add(pos.immutable())
+            }
+
+            nearbyLevers.clear()
+            nearbyLevers.addAll(found)
+        }
+
+        register<RenderWorldEvent> {
+            if (! LocationUtils.inDungeon) return@register
+            if (nearbyLevers.isEmpty()) return@register
+
+            val outline = mode.value.equalsOneOf(0, 2)
+            val fill = mode.value.equalsOneOf(1, 2)
+
+            for (pos in nearbyLevers) event.ctx.renderBlock(pos, outlineColor.value, fillColor.value, outline, fill, phase.value, lineWidth.value)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/noamm9/features/impl/floor7/P3BounceHelper.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/floor7/P3BounceHelper.kt
@@ -1,0 +1,42 @@
+package com.github.noamm9.features.impl.floor7
+
+import com.github.noamm9.config.types.ColorSetting
+import com.github.noamm9.config.types.SliderSetting
+import com.github.noamm9.event.impl.RenderWorldEvent
+import com.github.noamm9.features.Feature
+import com.github.noamm9.utils.location.LocationUtils
+import com.github.noamm9.utils.render.RenderHelper.renderX
+import com.github.noamm9.utils.render.RenderHelper.renderY
+import com.github.noamm9.utils.render.RenderHelper.renderZ
+import com.github.noamm9.utils.render.world.Render3D.renderCircle
+import net.minecraft.world.phys.Vec3
+import java.awt.Color
+import kotlin.math.tan
+
+/**
+ * @see com.github.noamm9.utils.location.LocationUtils.F7Phase
+ */
+object P3BounceHelper: Feature(
+    description = "Draws a horizontal ring in the sky at a -40° pitch reference, to help aim consistently during Necron's third phase (F7/M7).",
+    name = "P3 Bounce Helper"
+) {
+    private val radius by SliderSetting("Radius", 20, 5, 50, 1)
+    private val thickness by SliderSetting("Thickness", 2.0, 0.5, 5.0, 0.1)
+    private val color by ColorSetting("Color", Color.YELLOW)
+
+    override fun init() {
+        register<RenderWorldEvent> {
+            if (LocationUtils.F7Phase != 3) return@register
+            val player = mc.player ?: return@register
+
+            // Use the render-interpolated position (same pattern as RenderHelper.renderVec) rather
+            // than the raw per-tick player position - otherwise the ring visibly jitters between
+            // ticks instead of moving smoothly like e.g. WitherDragons' arrow stack indicator.
+            val eyeY = player.renderY + player.eyeHeight
+            val height = eyeY + radius.value * tan(Math.toRadians(40.0))
+            val center = Vec3(player.renderX, height, player.renderZ)
+
+            event.ctx.renderCircle(center, radius.value, color.value, thickness.value, phase = true)
+        }
+    }
+}


### PR DESCRIPTION
### Description
lever overlay, shows lever hitbox like if you would look with block overlay at it
### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other (please describe):

### How Has This Been Tested?

- [x] p3 sim