### PR TITLE
feat(Chat): chat search and infinite chat history

### DIFF
--- a/src/main/java/com/github/noamm9/interfaces/IChatComponent.java
+++ b/src/main/java/com/github/noamm9/interfaces/IChatComponent.java
@@ -7,5 +7,9 @@ import java.util.List;
 public interface IChatComponent {
     List<GuiMessage.Line> getVisibleMessages();
 
+    List<GuiMessage> getAllMessages();
+
     double getLineIndex();
+
+    void refreshChat();
 }

--- a/src/main/java/com/github/noamm9/mixin/MixinChatComponent.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinChatComponent.java
@@ -10,7 +10,9 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
@@ -20,17 +22,54 @@ import static com.github.noamm9.NoammAddons.mc;
 @Mixin(ChatComponent.class)
 public abstract class MixinChatComponent implements IChatComponent {
     @Shadow @Final private List<GuiMessage.Line> trimmedMessages;
+    @Shadow @Final private List<GuiMessage> allMessages;
     @Shadow private int chatScrollbarPos;
 
     @Shadow public abstract boolean isChatFocused();
+    @Shadow public abstract void resetChatScroll();
     @Shadow protected abstract int getWidth();
     @Shadow protected abstract double getScale();
     @Shadow public abstract int getLinesPerPage();
     @Shadow protected abstract int getLineHeight();
 
+    @Shadow private void refreshTrimmedMessages() {
+        throw new AssertionError();
+    }
+
     @Inject(method = "addServerSystemMessage", at = @At("HEAD"), cancellable = true)
     private void clearMessages(Component message, CallbackInfo ci) {
         Chat.addMassageHook(message, ci);
+    }
+
+    @Inject(method = "addMessageToDisplayQueue", at = @At("HEAD"), cancellable = true)
+    private void chatSearchHook(GuiMessage message, CallbackInfo ci) {
+        if (Chat.isHiddenBySearch(message)) ci.cancel();
+    }
+
+    @Inject(method = "clearMessages", at = @At("HEAD"))
+    private void chatClearedHook(boolean clearHistory, CallbackInfo ci) {
+        Chat.onChatCleared();
+    }
+
+    @ModifyConstant(method = "addMessageToQueue", constant = @Constant(intValue = 100))
+    private int modifyMaxHistory(int constant) {
+        return Chat.maxChatHistory(constant);
+    }
+
+    @ModifyConstant(method = "addMessageToDisplayQueue", constant = @Constant(intValue = 100))
+    private int modifyMaxTrimmedHistory(int constant) {
+        return Chat.maxChatHistory(constant);
+    }
+
+    @Override
+    public List<GuiMessage> getAllMessages() {
+        return this.allMessages;
+    }
+
+    @Override
+    public void refreshChat() {
+        resetChatScroll();
+        refreshTrimmedMessages();
     }
 
     @Override

--- a/src/main/java/com/github/noamm9/mixin/MixinChatScreen.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinChatScreen.java
@@ -1,0 +1,95 @@
+package com.github.noamm9.mixin;
+
+import com.github.noamm9.features.impl.general.Chat;
+import com.github.noamm9.ui.utils.componnents.ChatSearchBox;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.ChatScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.Component;
+import org.lwjgl.glfw.GLFW;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ChatScreen.class)
+public abstract class MixinChatScreen extends Screen {
+    @Shadow protected EditBox input;
+
+    @Unique private ChatSearchBox searchBox;
+
+    protected MixinChatScreen(Component title) {
+        super(title);
+    }
+
+    @Inject(method = "init", at = @At("TAIL"))
+    private void addSearchBox(CallbackInfo ci) {
+        searchBox = new ChatSearchBox(4, this.height - 26, this.width - 4, 12);
+        searchBox.setValue(Chat.getSearchQuery());
+        searchBox.setStatus(Chat::searchStatus);
+        searchBox.setResponder(Chat::setSearch);
+        searchBox.setVisible(Chat.isSearchBarOpen());
+
+        addRenderableWidget(searchBox);
+    }
+
+    @Inject(method = "setInitialFocus", at = @At("TAIL"))
+    private void focusSearchBox(CallbackInfo ci) {
+        if (searchBox != null && searchBox.isVisible()) setFocused(searchBox);
+    }
+
+    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
+    private void searchKeyPressed(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
+        if (searchBox == null) return;
+
+        if (event.hasControlDown() && event.key() == GLFW.GLFW_KEY_F) {
+            if (! Chat.isSearchAvailable()) return;
+            toggleSearchBox();
+            cir.setReturnValue(true);
+            return;
+        }
+
+        if (! searchBox.isVisible() || ! searchBox.isFocused()) return;
+
+        if (event.isEscape()) {
+            toggleSearchBox();
+            cir.setReturnValue(true);
+            return;
+        }
+
+        // Enter keeps the filter applied and hands the focus back to the chat input.
+        if (event.key() == GLFW.GLFW_KEY_ENTER || event.key() == GLFW.GLFW_KEY_KP_ENTER) {
+            setFocused(input);
+            cir.setReturnValue(true);
+            return;
+        }
+
+        searchBox.keyPressed(event);
+        cir.setReturnValue(true);
+    }
+
+    @Inject(method = "removed", at = @At("TAIL"))
+    private void closeSearchBox(CallbackInfo ci) {
+        Chat.closeSearchBar();
+    }
+
+    @Unique
+    private void toggleSearchBox() {
+        boolean open = Chat.toggleSearchBar();
+
+        searchBox.setVisible(open);
+        if (open) {
+            searchBox.setValue(Chat.getSearchQuery());
+            searchBox.moveCursorToEnd(false);
+            setFocused(searchBox);
+        }
+        else {
+            searchBox.setValue("");
+            setFocused(input);
+        }
+    }
+}

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/Chat.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/Chat.kt
@@ -34,7 +34,7 @@ object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy me
     private val removeUselessMessages by ToggleSetting("Remove useless messages", true).withDescription("Removes a lot of useless messages from the chat.")
 
     private val chatSearch by ToggleSetting("Chat Search", true)
-        .withDescription("Adds /chatsearch <query> to filter the chat down to the messages that match a query.")
+        .withDescription("Press Ctrl + F while the chat is open to search it, only the matching messages stay visible. Also adds /chatsearch <query>.")
     private val searchCaseSensitive by ToggleSetting("Case Sensitive Search")
         .withDescription("Makes chat searches match the exact casing of the query.").showIf { chatSearch.value }
     private val searchRegex by ToggleSetting("Regex Search")
@@ -95,6 +95,7 @@ object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy me
 
     override fun onDisable() {
         super.onDisable()
+        searchBarOpen = false
         clearSearch(silent = true)
     }
 
@@ -134,9 +135,51 @@ object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy me
     }
 
     private var searchMatcher: ((String) -> Boolean)? = null
+    private var searchBarOpen = false
     private val modPrefix = NoammAddons.PREFIX.removeFormatting()
 
+    /** Amount of stored messages the active search matches, `-1` when no search is active. */
+    private var searchMatches = - 1
+
+    private var searchQuery = ""
+
     internal val searchAvailable get() = enabled && chatSearch.value
+
+    @JvmStatic fun isSearchAvailable() = searchAvailable
+    @JvmStatic fun isSearchBarOpen() = searchBarOpen
+    @JvmStatic fun getSearchQuery() = searchQuery
+
+    /** Status text drawn on the right side of the search bar. */
+    @JvmStatic
+    fun searchStatus(): String {
+        if (searchQuery.isBlank()) return ""
+        if (searchMatcher == null) return "§cinvalid regex"
+        return "§7$searchMatches match${if (searchMatches == 1) "" else "es"}"
+    }
+
+    /** Ctrl + F, returns whether the bar ended up open. */
+    @JvmStatic
+    fun toggleSearchBar(): Boolean {
+        searchBarOpen = ! searchBarOpen
+        if (! searchBarOpen) setSearch("")
+        return searchBarOpen
+    }
+
+    @JvmStatic
+    fun closeSearchBar() {
+        if (! searchBarOpen) return
+        searchBarOpen = false
+        setSearch("")
+    }
+
+    /** Applies [query] to the chat without printing anything, used by the search bar. */
+    @JvmStatic
+    fun setSearch(query: String) {
+        searchQuery = query
+        searchMatcher = if (query.isBlank()) null else buildMatcher(query)
+        searchMatches = countMatches()
+        chatHud()?.refreshChat()
+    }
 
     /** Called by [com.github.noamm9.mixin.MixinChatComponent] for every message about to be displayed. */
     @JvmStatic
@@ -152,6 +195,7 @@ object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy me
     @JvmStatic
     fun onChatCleared() {
         searchMatcher = null
+        searchMatches = - 1
     }
 
     /** Called by [com.github.noamm9.mixin.MixinChatComponent] to raise the vanilla 100 message cap. */
@@ -161,16 +205,13 @@ object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy me
         return maxOf(vanilla, chatHistorySize.value)
     }
 
+    /** /chatsearch, same filter as the search bar but with chat feedback. */
     internal fun search(query: String) {
         if (! searchAvailable) return ChatUtils.modMessage("&cThe &bChat Search &coption is disabled.")
-        val chatHud = chatHud() ?: return ChatUtils.modMessage("&cChat is not available right now.")
-        val matcher = buildMatcher(query) ?: return ChatUtils.modMessage("&cInvalid Regex syntax!")
+        if (buildMatcher(query) == null) return ChatUtils.modMessage("&cInvalid Regex syntax!")
 
-        searchMatcher = matcher
-        val matches = chatHud.allMessages.count { matcher(it.content().unformattedText) }
-        chatHud.refreshChat()
-
-        ChatUtils.modMessage("&aFound &e$matches&a message${if (matches == 1) "" else "s"} matching &e$query&a. &7(/chatsearch to clear)")
+        setSearch(query)
+        ChatUtils.modMessage("&aFound &e$searchMatches&a message${if (searchMatches == 1) "" else "s"} matching &e$query&a. &7(/chatsearch to clear)")
     }
 
     internal fun clearSearch(silent: Boolean = false) {
@@ -179,9 +220,13 @@ object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy me
             return
         }
 
-        searchMatcher = null
-        chatHud()?.refreshChat()
+        setSearch("")
         if (! silent) ChatUtils.modMessage("&aCleared the chat search.")
+    }
+
+    private fun countMatches(): Int {
+        val matcher = searchMatcher ?: return - 1
+        return chatHud()?.allMessages?.count { matcher(it.content().unformattedText) } ?: - 1
     }
 
     private fun buildMatcher(query: String): ((String) -> Boolean)? {

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/Chat.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/Chat.kt
@@ -3,6 +3,7 @@ package com.github.noamm9.features.impl.general
 import com.github.noamm9.NoammAddons
 import com.github.noamm9.commands.CommandBuilder
 import com.github.noamm9.config.PogObject
+import com.github.noamm9.config.types.SliderSetting
 import com.github.noamm9.config.types.ToggleSetting
 import com.github.noamm9.event.impl.ChatMessageEvent
 import com.github.noamm9.event.impl.MouseClickEvent
@@ -31,6 +32,18 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
 object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy messages."), ICommandProvider {
     private val ctrlClickToCopy by ToggleSetting("Ctrl Click to Copy", true).withDescription("Ctrl + Left Click a message to copy it to your clipboard.")
     private val removeUselessMessages by ToggleSetting("Remove useless messages", true).withDescription("Removes a lot of useless messages from the chat.")
+
+    private val chatSearch by ToggleSetting("Chat Search", true)
+        .withDescription("Adds /chatsearch <query> to filter the chat down to the messages that match a query.")
+    private val searchCaseSensitive by ToggleSetting("Case Sensitive Search")
+        .withDescription("Makes chat searches match the exact casing of the query.").showIf { chatSearch.value }
+    private val searchRegex by ToggleSetting("Regex Search")
+        .withDescription("Treats the search query as a Regex instead of plain text.").showIf { chatSearch.value }
+
+    private val infiniteChatHistory by ToggleSetting("Infinite Chat History")
+        .withDescription("Keeps way more than the vanilla 100 messages in the chat so you can scroll back through old messages.")
+    private val chatHistorySize by SliderSetting("Chat History Size", 1000, 100, 20000, 100)
+        .withDescription("How many messages to keep when Infinite Chat History is on.").showIf { infiniteChatHistory.value }
 
     //#if CHEAT
     private val autoDialogue by ToggleSetting("Auto dialogue").withDescription("Automatically continues dialogues with NPCs.")
@@ -80,6 +93,11 @@ object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy me
         }
     }
 
+    override fun onDisable() {
+        super.onDisable()
+        clearSearch(silent = true)
+    }
+
     override fun init() {
         register<MouseClickEvent> {
             if (! ctrlClickToCopy.value) return@register
@@ -114,6 +132,70 @@ object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy me
         }
         //#endif
     }
+
+    private var searchMatcher: ((String) -> Boolean)? = null
+    private val modPrefix = NoammAddons.PREFIX.removeFormatting()
+
+    internal val searchAvailable get() = enabled && chatSearch.value
+
+    /** Called by [com.github.noamm9.mixin.MixinChatComponent] for every message about to be displayed. */
+    @JvmStatic
+    fun isHiddenBySearch(message: GuiMessage): Boolean {
+        if (! searchAvailable) return false
+        val matcher = searchMatcher ?: return false
+        val text = message.content().unformattedText
+        if (text.startsWith(modPrefix)) return false
+        return ! matcher(text)
+    }
+
+    /** Called by [com.github.noamm9.mixin.MixinChatComponent] whenever the chat gets wiped. */
+    @JvmStatic
+    fun onChatCleared() {
+        searchMatcher = null
+    }
+
+    /** Called by [com.github.noamm9.mixin.MixinChatComponent] to raise the vanilla 100 message cap. */
+    @JvmStatic
+    fun maxChatHistory(vanilla: Int): Int {
+        if (! enabled || ! infiniteChatHistory.value) return vanilla
+        return maxOf(vanilla, chatHistorySize.value)
+    }
+
+    internal fun search(query: String) {
+        if (! searchAvailable) return ChatUtils.modMessage("&cThe &bChat Search &coption is disabled.")
+        val chatHud = chatHud() ?: return ChatUtils.modMessage("&cChat is not available right now.")
+        val matcher = buildMatcher(query) ?: return ChatUtils.modMessage("&cInvalid Regex syntax!")
+
+        searchMatcher = matcher
+        val matches = chatHud.allMessages.count { matcher(it.content().unformattedText) }
+        chatHud.refreshChat()
+
+        ChatUtils.modMessage("&aFound &e$matches&a message${if (matches == 1) "" else "s"} matching &e$query&a. &7(/chatsearch to clear)")
+    }
+
+    internal fun clearSearch(silent: Boolean = false) {
+        if (searchMatcher == null) {
+            if (! silent) ChatUtils.modMessage("&cThere is no active chat search.")
+            return
+        }
+
+        searchMatcher = null
+        chatHud()?.refreshChat()
+        if (! silent) ChatUtils.modMessage("&aCleared the chat search.")
+    }
+
+    private fun buildMatcher(query: String): ((String) -> Boolean)? {
+        if (searchRegex.value) {
+            val options = if (searchCaseSensitive.value) emptySet() else setOf(RegexOption.IGNORE_CASE)
+            val regex = catch { Regex(query, options) } ?: return null
+            return { regex.containsMatchIn(it) }
+        }
+
+        val needle = if (searchCaseSensitive.value) query else query.lowercase()
+        return { (if (searchCaseSensitive.value) it else it.lowercase()).contains(needle) }
+    }
+
+    private fun chatHud() = UMinecraft.getChatGUI() as? IChatComponent
 
     @JvmStatic
     fun addMassageHook(comp: Component, ci: CallbackInfo) {
@@ -171,5 +253,17 @@ object Chat: Feature("Useful tweaks for the chat such as Ctrl + Click to copy me
 
         val text = builder.toString()
         return if ("chat" in NoammAddons.debugFlags) text else text.removeFormatting()
+    }
+}
+
+object ChatSearch: ICommandProvider {
+    override fun CommandBuilder.command() {
+        setName("chatsearch")
+        description("Filters the chat to messages matching a query, run without a query to clear it")
+        runs { Chat.clearSearch() }
+
+        argument("query", StringArgumentType.greedyString()) {
+            runs { Chat.search(StringArgumentType.getString(it, "query")) }
+        }
     }
 }

--- a/src/main/kotlin/com/github/noamm9/ui/utils/componnents/ChatSearchBox.kt
+++ b/src/main/kotlin/com/github/noamm9/ui/utils/componnents/ChatSearchBox.kt
@@ -1,0 +1,37 @@
+package com.github.noamm9.ui.utils.componnents
+
+import com.github.noamm9.NoammAddons.mc
+import com.github.noamm9.utils.render.Render2D.drawRect
+import com.github.noamm9.utils.render.Render2D.drawString
+import com.github.noamm9.utils.render.RenderHelper.width
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.client.gui.components.EditBox
+import net.minecraft.network.chat.Component
+import java.awt.Color
+
+/**
+ * The search bar that gets opened above the chat input with Ctrl + F.
+ * Mirrors the look of the vanilla chat input, with the match count drawn on the right.
+ */
+class ChatSearchBox(x: Int, y: Int, width: Int, height: Int): EditBox(mc.font, x, y, width, height, Component.literal("Chat Search")) {
+    /** Text drawn on the right side of the bar, usually the amount of matches. */
+    var status: () -> String = { "" }
+
+    init {
+        isBordered = false
+        setMaxLength(256)
+        setTextColor(Color.WHITE.rgb)
+        setHint(Component.literal("Search chat... (Esc to close)"))
+    }
+
+    override fun extractWidgetRenderState(guiGraphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, partialTick: Float) {
+        if (! this.isVisible) return
+
+        guiGraphics.drawRect(2f, (y - 1).toFloat(), (width + 2).toFloat(), (height + 2).toFloat(), Color(0, 0, 0, 140))
+        super.extractWidgetRenderState(guiGraphics, mouseX, mouseY, partialTick)
+
+        val status = status()
+        if (status.isEmpty()) return
+        guiGraphics.drawString(status, x + width - status.width() - 4f, y + height / 2f - 4f, Color(170, 170, 170))
+    }
+}


### PR DESCRIPTION
Adds two new options to the **Chat** feature.

### Chat Search (Ctrl + F)
Press **Ctrl + F** while the chat is open: a second input bar opens right above the chat input, and typing in it filters the chat live so only the matching messages stay visible. The match count is drawn on the right side of the bar.

- **Enter** applies the filter and hands focus back to the chat input.
- **Escape** (or Ctrl + F again) closes the bar and restores the full chat.
- Closing the chat drops the filter too, so it can never keep hiding messages while you aren't looking at it.
- `/chatsearch <query>` still works as the persistent, non-GUI way to do the same thing (`/chatsearch` with no arguments clears it).
- **Case Sensitive Search** / **Regex Search** toggles control how the query is matched (plain substring, case-insensitive by default). An invalid regex shows as `invalid regex` in the bar instead of filtering.
- Mod messages (`[NA] ...`) are never hidden, so mod feedback stays visible while a search is active.
- The filter only gates the *display* queue (`addMessageToDisplayQueue`), so messages that arrive while a search is active are still stored in `allMessages` and reappear once it's cleared. Vanilla's `visibleMessageFilter` was deliberately not used because it drops non-matching messages entirely.
- The search is also dropped when the chat gets cleared (world swap) or the feature is toggled off.

### Infinite Chat History
- **Infinite Chat History** toggle + **Chat History Size** slider (100–20000, default 1000) raise vanilla's hardcoded 100 message / 100 line caps via `@ModifyConstant` on `addMessageToQueue` and `addMessageToDisplayQueue`, so you can scroll back much further.
- With the toggle off, the vanilla constant is returned untouched.

### Other
- New `MixinChatScreen` (search bar wiring) and `ChatSearchBox` component (chat-input-styled edit box with the match counter).
- `IChatComponent` now also exposes `getAllMessages()` and `refreshChat()` (reset scroll + `refreshTrimmedMessages`).

### Testing
`compileKotlin` and `compileJava` pass. Note: `26.1.2` currently fails to compile because `MixinItemModelResolver` still imports the removed `RevertAxes` class (b6a7c1f) — unrelated to this PR; I verified compilation with that file temporarily moved aside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)