### PR TITLE
fix(AutoI4): correct leap menu scheduler delay and restore input-bloc…

### DIFF
--- a/src/main/kotlin/com/github/noamm9/utils/ActionUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/ActionUtils.kt
@@ -38,9 +38,13 @@ object ActionUtils: ISelfInit {
     private suspend fun run() {
         while (actionQueue.isNotEmpty()) {
             val action = synchronized(lock) { actionQueue.poll() } ?: break
-            if (action.blockInput) ThreadUtils.setTimeout(5000) { isBlocked = false }
             isBlocked = action.blockInput
-            action.block()
+            if (action.blockInput) ThreadUtils.setTimeout(5000) { isBlocked = false }
+            try {
+                action.block()
+            } finally {
+                isBlocked = false
+            }
         }
         running = false
     }

--- a/src/main/kotlin/com/github/noamm9/utils/ActionUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/ActionUtils.kt
@@ -2,14 +2,11 @@ package com.github.noamm9.utils
 
 import com.github.noamm9.NoammAddons.scope
 import com.github.noamm9.event.EventBus
-import com.github.noamm9.event.impl.KeyboardEvent
-import com.github.noamm9.event.impl.MouseClickEvent
-import com.github.noamm9.event.impl.WorldChangeEvent
+import com.github.noamm9.event.impl.*
 import com.github.noamm9.init.types.ISelfInit
 import com.github.noamm9.utils.ThreadUtils.scheduledTask
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.*
+import java.lang.Runnable
 import java.util.concurrent.*
 import kotlin.coroutines.resume
 
@@ -31,20 +28,17 @@ object ActionUtils: ISelfInit {
     fun queue(priority: Int = 0, blockInput: Boolean = false, block: suspend () -> Unit) = synchronized(lock) {
         actionQueue.add(Action(priority, blockInput, block))
         if (running) return@synchronized
-        running = true
         processingJob = scope.launch { run() }
     }
 
     private suspend fun run() {
+        running = true
         while (actionQueue.isNotEmpty()) {
             val action = synchronized(lock) { actionQueue.poll() } ?: break
-            isBlocked = action.blockInput
             if (action.blockInput) ThreadUtils.setTimeout(5000) { isBlocked = false }
-            try {
-                action.block()
-            } finally {
-                isBlocked = false
-            }
+            isBlocked = action.blockInput
+            catch { action.block() }
+            isBlocked = false
         }
         running = false
     }

--- a/src/main/kotlin/com/github/noamm9/utils/PlayerUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/PlayerUtils.kt
@@ -229,8 +229,9 @@ object PlayerUtils: ISelfInit, Shortcuts {
                     player.closeContainer()
                 }
 
-                "spirit leap" if awaitingLeap != null -> Scheduler.schedule(2) {
+                "spirit leap" if awaitingLeap != null -> Scheduler.schedule(100) {
                     val leapTarget = awaitingLeap ?: return@schedule
+                    awaitingLeap = null
 
                     LeapMenu.updateLeapMenu()
                     LeapMenu.players.find { it?.player?.name == leapTarget.name }?.let { target ->
@@ -238,7 +239,6 @@ object PlayerUtils: ISelfInit, Shortcuts {
                         GuiUtils.clickSlot(target.slotIndex, GuiUtils.ButtonType.LEFT)
                     }
                     player.closeContainer()
-                    awaitingLeap = null
                 }
             }
         }

--- a/src/main/kotlin/com/github/noamm9/utils/PlayerUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/PlayerUtils.kt
@@ -32,9 +32,7 @@ import net.minecraft.world.entity.EquipmentSlot
 import net.minecraft.world.entity.player.Inventory
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
-import net.minecraft.world.phys.BlockHitResult
-import net.minecraft.world.phys.HitResult
-import net.minecraft.world.phys.Vec3
+import net.minecraft.world.phys.*
 import kotlin.math.abs
 import kotlin.math.min
 
@@ -158,8 +156,6 @@ object PlayerUtils: ISelfInit, Shortcuts {
     private var awaitingLeap: DungeonPlayer? = null
 
     suspend fun changeMaskAction() = quickSwapAction("SPIRIT_MASK", "BONZO_MASK")
-
-
     suspend fun quickSwapAction(vararg itemIDs: String) {
         if (thePlayer?.isDead == true) return
 
@@ -205,17 +201,20 @@ object PlayerUtils: ISelfInit, Shortcuts {
     suspend fun rodSwap() {
         val found = findHotbarSlot { it.item == Items.FISHING_ROD } ?: return modMessage("&cNo Fishing Rod found in hotbar!")
         val prev = player.inventory.selectedSlot
+        val hold = mc.options.keyUse.isDown
 
         swapToSlot(found)
         waitTicks(2, ::rightClick)
         waitTicks(2) { swapToSlot(prev) }
         delay(100)
+
+        mc.options.keyUse.isDown = hold
     }
 
     override fun init() {
         register<ContainerFullyOpenedEvent> {
             when (event.title.unformattedText.lowercase().trim()) {
-                "stats & equipment" if awaiting4EQ.isNotEmpty() -> Scheduler.schedule(7) {
+                "stats & equipment" if awaiting4EQ.isNotEmpty() -> Scheduler.schedule(350) {
                     val con = player.containerMenu.slots
                     val item = con.filter { it.index in con.size - 36 until con.size }.find { slot ->
                         awaiting4EQ.any(slot.item.skyblockId::contains)


### PR DESCRIPTION

Fixes two related AutoI4 bugs affecting players with medium-high ping (confirmed at ~110ms).

Bug 1 — autoleap fails intermittently (opens leap menu, doesn't leap): in PlayerUtils.kt, the leap menu handler calls Scheduler.schedule(2) { ... }, intending a 2-tick delay before reading LeapMenu.players (replacing the old ThreadUtils.scheduledTask(2) call in 5ddd965b). Scheduler.schedule's first parameter is milliseconds, not ticks (fun schedule(msDelay: Int, tickDelay: Int = msDelay / 50, action: Runnable)), so Scheduler.schedule(2) sets msDelay = 2 and tickDelay defaults to 2 / 50 = 0 via integer division. The tick condition is satisfied almost immediately instead of after ~100ms, so on higher ping the server hasn't sent the leap menu contents yet, LeapMenu.players.find { ... } finds nothing, and no leap fires. Fix: call Scheduler.schedule(100) so tickDelay correctly resolves to 2.

Bug 2 — autorod causes a full input softlock after use: in ActionUtils.kt, run() used to reset isBlocked = false in a finally block immediately after an action completed, with a 5-second ThreadUtils.setTimeout only as a backup failsafe. Commit cf3ddd0d removed the finally block while refactoring for thread safety, leaving the 5-second timeout as the only way isBlocked ever gets cleared. Since rodSwap() runs via queue(2, true, PlayerUtils::rodSwap) (blockInput = true), every rod swap now blocks all input for a full 5 seconds regardless of how quickly the swap itself finishes (~500ms). Fix: restore the try/finally reset around action.block(), keeping the timeout as backup.

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other (please describe):

### How Has This Been Tested?
- [x] In-game testing across multiple m7 runs at ~110ms ping
- [x] Compared behavior against 1.2.3 baseline (~300 runs, near-zero failures) vs. unpatched 1.2.6 (~70% autoleap failure rate, 100% autorod failure rate)
- [x] Verified root cause by diffing source between 1.2.3 and 1.2.6 and checking the fix against Scheduler.kt's schedule()/process() implementation directly