### PR TITLE
fix(secretsHUD): not showing configurable prefix in hud editor

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
@@ -52,7 +52,7 @@ object Secrets: Feature() {
 
     override fun init() {
         hudElement("Secret Hud", { hudDisplay.value }, { LocationUtils.inDungeon && ! LocationUtils.inBoss }) { ctx, example ->
-            val line = if (example) "&7Secrets: &c3&7/&a7"
+            val line = if (example) "${if (hudPrefix.value.isBlank()) "" else "&7${hudPrefix.value} "}&c3&7/&a7"
             else {
                 val max = ActionBarParser.maxSecrets ?: return@hudElement 0f to 0f
                 val current = ActionBarParser.secrets ?: return@hudElement 0f to 0f


### PR DESCRIPTION
### Description

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other (please describe):

### How Has This Been Tested?

- [x] ingame verification
